### PR TITLE
Add checkbox "Is RF" to Learn page

### DIFF
--- a/cmd/httpassets/tmpl/learn.html
+++ b/cmd/httpassets/tmpl/learn.html
@@ -58,6 +58,10 @@
 			 <label>Learn From:</label>
 		    {{.DeviceList}}	
 		    </div>
+        <div>
+          <label>Is RF:</label>
+          <input type="checkbox" name='rf'>
+        </div>
 	          <div class="form-group">
 	      <input name='submit' value='Start Learning' type='submit' />
 	        </div>


### PR DESCRIPTION
- Call broadlink.Learn or broadlink.LearnRF based on checkbox value
- Minor refactoring in learnHandler to construct src value for iframe
- Optionally include "/rf/" at the end of src value
NOTE: This invalidates the check of len(parts) < 3 in learnChildHandler